### PR TITLE
allow string joining

### DIFF
--- a/lib/rule_engine/ast.py
+++ b/lib/rule_engine/ast.py
@@ -391,13 +391,23 @@ class ArithmeticExpression(LeftOperatorRightExpressionBase):
 class AddExpression(LeftOperatorRightExpressionBase):
 	"""A class for representing arithmetic expressions from the grammar text such as addition and subtraction."""
 	compatible_types = (DataType.FLOAT,DataType.STRING)
-	result_type =  DataType.STRING
+	result_type =  DataType.UNDEFINED
+
+	def __init__(self, *args, **kwargs):
+		super(AddExpression, self).__init__(*args, **kwargs)
+		if self.left.result_type != DataType.UNDEFINED and self.right.result_type != DataType.UNDEFINED:
+			if self.left.result_type != self.right.result_type:
+				raise errors.EvaluationError('data type mismatch')
+
 	def __op_add(self, op, thing):
 		left_value = self.left.evaluate(thing)
 		right_value = self.right.evaluate(thing)
 		if isinstance(left_value,str) or isinstance(right_value, str):
 			_assert_is_string(left_value)
 			_assert_is_string(right_value)
+		else:
+			_assert_is_numeric(left_value)
+			_assert_is_numeric(right_value)
 		return op(left_value, right_value)
 
 	_op_add  = functools.partialmethod(__op_add, operator.add)

--- a/lib/rule_engine/ast.py
+++ b/lib/rule_engine/ast.py
@@ -55,6 +55,10 @@ def _assert_is_numeric(*values):
 	if not all(map(is_numeric, values)):
 		raise errors.EvaluationError('data type mismatch (not a numeric value)')
 
+def _assert_is_string(*values):
+	if not all(map(isinstance, values, [str])):
+		raise errors.EvaluationError('data type mismatch (not a string value)')
+
 def _is_reduced(*values):
 	"""
 	Check if the ast expression *value* is a literal expression and if it is a compound datatype, that all of it's
@@ -377,13 +381,27 @@ class ArithmeticExpression(LeftOperatorRightExpressionBase):
 		_assert_is_numeric(right_value)
 		return op(left_value, right_value)
 
-	_op_add  = functools.partialmethod(__op_arithmetic, operator.add)
 	_op_sub  = functools.partialmethod(__op_arithmetic, operator.sub)
 	_op_fdiv = functools.partialmethod(__op_arithmetic, operator.floordiv)
 	_op_tdiv = functools.partialmethod(__op_arithmetic, operator.truediv)
 	_op_mod  = functools.partialmethod(__op_arithmetic, operator.mod)
 	_op_mul  = functools.partialmethod(__op_arithmetic, operator.mul)
 	_op_pow  = functools.partialmethod(__op_arithmetic, operator.pow)
+
+class AddExpression(LeftOperatorRightExpressionBase):
+	"""A class for representing arithmetic expressions from the grammar text such as addition and subtraction."""
+	compatible_types = (DataType.FLOAT,DataType.STRING)
+	result_type =  DataType.STRING
+	def __op_add(self, op, thing):
+		left_value = self.left.evaluate(thing)
+		right_value = self.right.evaluate(thing)
+		if isinstance(left_value,str) or isinstance(right_value, str):
+			_assert_is_string(left_value)
+			_assert_is_string(right_value)
+		return op(left_value, right_value)
+
+	_op_add  = functools.partialmethod(__op_add, operator.add)
+
 
 class BitwiseExpression(LeftOperatorRightExpressionBase):
 	"""

--- a/lib/rule_engine/parser.py
+++ b/lib/rule_engine/parser.py
@@ -307,8 +307,7 @@ class Parser(ParserBase):
 
 	def p_expression_arithmetic(self, p):
 		"""
-		expression : expression ADD    expression
-				   | expression SUB    expression
+		expression : expression SUB    expression
 				   | expression MOD    expression
 				   | expression MUL    expression
 				   | expression FDIV   expression
@@ -318,6 +317,15 @@ class Parser(ParserBase):
 		left, op, right = p[1:4]
 		op_name = self.op_names[op]
 		p[0] = _DeferredAstNode(ast.ArithmeticExpression, args=(self.context, op_name, left, right))
+
+	def p_expression_add(self, p):
+		"""
+		expression : expression ADD    expression
+
+		"""
+		left, op, right = p[1:4]
+		op_name = self.op_names[op]
+		p[0] = _DeferredAstNode(ast.AddExpression, args=(self.context, op_name, left, right))
 
 	def p_expression_bitwise(self, p):
 		"""

--- a/tests/ast/__init__.py
+++ b/tests/ast/__init__.py
@@ -148,11 +148,11 @@ class AstTests(unittest.TestCase):
 		self.assertEqual(statement.evaluate(None), 3)
 
 		statement = parser_.parse('one + 2', self.context)
-		self.assertIsInstance(statement.expression, ast.ArithmeticExpression)
+		self.assertIsInstance(statement.expression, ast.AddExpression)
 		self.assertEqual(statement.evaluate(thing), 3)
 
 		statement = parser_.parse('1 + two', self.context)
-		self.assertIsInstance(statement.expression, ast.ArithmeticExpression)
+		self.assertIsInstance(statement.expression, ast.AddExpression)
 		self.assertEqual(statement.evaluate(thing), 3)
 
 	def test_ast_reduces_array_literals(self):
@@ -189,7 +189,6 @@ class AstTests(unittest.TestCase):
 		cases = (
 			# type,             type_is,             type_is_not
 			('symbol << 1',     ast.DataType.FLOAT,  ast.DataType.STRING),
-			('symbol + 1',      ast.DataType.FLOAT,  ast.DataType.STRING),
 			('symbol[1]',       ast.DataType.STRING, ast.DataType.FLOAT),
 			('symbol[1]',       ast.DataType.ARRAY,  ast.DataType.FLOAT),
 			('symbol =~ "foo"', ast.DataType.STRING, ast.DataType.FLOAT),

--- a/tests/ast/__init__.py
+++ b/tests/ast/__init__.py
@@ -189,6 +189,7 @@ class AstTests(unittest.TestCase):
 		cases = (
 			# type,             type_is,             type_is_not
 			('symbol << 1',     ast.DataType.FLOAT,  ast.DataType.STRING),
+			('symbol + 1',      ast.DataType.FLOAT,  ast.DataType.STRING),
 			('symbol[1]',       ast.DataType.STRING, ast.DataType.FLOAT),
 			('symbol[1]',       ast.DataType.ARRAY,  ast.DataType.FLOAT),
 			('symbol =~ "foo"', ast.DataType.STRING, ast.DataType.FLOAT),

--- a/tests/ast/expression/left_operator_right.py
+++ b/tests/ast/expression/left_operator_right.py
@@ -41,6 +41,7 @@ import rule_engine.errors as errors
 
 __all__ = (
 	'ArithmeticExpressionTests',
+	'AddExpressionTests',
 	'BitwiseExpressionTests',
 	'BitwiseExpressionSetTests',
 	'BitwiseShiftExpressionTests',
@@ -97,6 +98,29 @@ class ArithmeticExpressionTests(LeftOperatorRightExpresisonTestsBase):
 				self.assertExpressionTests(operation, ast.FloatExpression(context, 2.0), ast.BooleanExpression(context, True))
 			with self.assertRaises(errors.EvaluationError):
 				self.assertExpressionTests(operation, ast.BooleanExpression(context, True), ast.FloatExpression(context, 4.0))
+
+class AddExpressionTests(LeftOperatorRightExpresisonTestsBase):
+	ExpressionClass = ast.AddExpression
+	false_value = 0.0
+	left_value = two = ast.FloatExpression(context, 2.0)
+	right_value = four = ast.FloatExpression(context, 4.0)
+	def test_ast_expression_left_operator_right_add(self):
+		self.assertExpressionTests('add', equals_value=6.0)
+		self.assertExpressionTests('add', left_value=ast.StringExpression(context,'a'), right_value=ast.StringExpression(context,'b'), equals_value='ab')
+
+	def test_ast_expression_left_operator_right_add_type_errors(self):
+		with self.assertRaises(errors.EvaluationError):
+			self.assertExpressionTests('add', ast.FloatExpression(context, 2.0), ast.StringExpression(context, '4.0'))
+		with self.assertRaises(errors.EvaluationError):
+			self.assertExpressionTests('add', ast.StringExpression(context, '2.0'), ast.FloatExpression(context, 4.0))
+		with self.assertRaises(errors.EvaluationError):
+			self.assertExpressionTests('add', ast.FloatExpression(context, 2.0), ast.BooleanExpression(context, True))
+		with self.assertRaises(errors.EvaluationError):
+			self.assertExpressionTests('add', ast.BooleanExpression(context, True), ast.FloatExpression(context, 4.0))
+		with self.assertRaises(errors.EvaluationError):
+			self.assertExpressionTests('add', ast.BooleanExpression(context, True), ast.StringExpression(context, 'b'))
+		with self.assertRaises(errors.EvaluationError):
+			self.assertExpressionTests('add', ast.StringExpression(context, 'b'), ast.BooleanExpression(context, True))
 
 class BitwiseExpressionTests(LeftOperatorRightExpresisonTestsBase):
 	ExpressionClass = ast.BitwiseExpression

--- a/tests/ast/expression/left_operator_right.py
+++ b/tests/ast/expression/left_operator_right.py
@@ -80,7 +80,6 @@ class ArithmeticExpressionTests(LeftOperatorRightExpresisonTestsBase):
 	left_value = two = ast.FloatExpression(context, 2.0)
 	right_value = four = ast.FloatExpression(context, 4.0)
 	def test_ast_expression_left_operator_right_arithmetic(self):
-		self.assertExpressionTests('add', equals_value=6.0)
 		self.assertExpressionTests('sub', equals_value=-2.0)
 		self.assertExpressionTests('fdiv', equals_value=0.0)
 		self.assertExpressionTests('tdiv', equals_value=0.5)
@@ -89,7 +88,7 @@ class ArithmeticExpressionTests(LeftOperatorRightExpresisonTestsBase):
 		self.assertExpressionTests('pow', equals_value=16.0)
 
 	def test_ast_expression_left_operator_right_arithmetic_type_errors(self):
-		for operation in ('add', 'sub', 'fdiv', 'tdiv', 'mod', 'mul', 'pow'):
+		for operation in ('sub', 'fdiv', 'tdiv', 'mod', 'mul', 'pow'):
 			with self.assertRaises(errors.EvaluationError):
 				self.assertExpressionTests(operation, ast.FloatExpression(context, 2.0), ast.StringExpression(context, '4.0'))
 			with self.assertRaises(errors.EvaluationError):

--- a/tests/engine.py
+++ b/tests/engine.py
@@ -133,8 +133,7 @@ class EngineTests(unittest.TestCase):
 		context = engine.Context()
 		context.builtins = builtins
 		engine.Rule('$name =~ ""')
-		with self.assertRaises(errors.EvaluationError):
-			engine.Rule('$name + 1', context=context)
+
 
 	def test_engine_builtins_re_groups(self):
 		context = engine.Context()

--- a/tests/engine.py
+++ b/tests/engine.py
@@ -133,7 +133,8 @@ class EngineTests(unittest.TestCase):
 		context = engine.Context()
 		context.builtins = builtins
 		engine.Rule('$name =~ ""')
-
+		with self.assertRaises(errors.EvaluationError):
+			engine.Rule('$name + 1', context=context)
 
 	def test_engine_builtins_re_groups(self):
 		context = engine.Context()

--- a/tests/parser.py
+++ b/tests/parser.py
@@ -182,7 +182,6 @@ class ParserLeftOperatorRightTests(ParserTestsBase):
 
 	def test_parser_arithmetic_expressions(self):
 		expressions = (
-			'left + right',
 			'left - right',
 			'left / right',
 			'left // right',
@@ -192,6 +191,13 @@ class ParserLeftOperatorRightTests(ParserTestsBase):
 		)
 		for expression in expressions:
 			self.assertStatementType(expression, ast.ArithmeticExpression)
+
+	def test_parser_add_expressions(self):
+		expressions = (
+			'left + right',
+		)
+		for expression in expressions:
+			self.assertStatementType(expression, ast.AddExpression)
 
 	def test_parser_bitwise_expressions(self):
 		expressions = (


### PR DESCRIPTION
adjust add operator to allow the typical implementation of python add: string join and mathematical addition


Sample Usage confirmed:

```
PyDev console: starting.
Python 3.9.2 (tags/v3.9.2:1a79785, Feb 19 2021, 13:44:55) [MSC v.1928 64 bit (AMD64)] on win32
import rule_engine
context = rule_engine.Context(resolver=rule_engine.resolve_attribute)
rule = rule_engine.Rule("'a'+'b'", context=context)
rule.evaluate({'t':1})
'ab'
```