### PR TITLE
Update getting_started.rst

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -355,7 +355,7 @@ will be added in addition to the default builtin symbols.
            # call the parent class's __init__ method first to set the
            # default_timezone attribute
            super(CustomBuiltinsContext, self).__init__(*args, **kwargs)
-           self.builtins = rule_engine.engine.Builtins.from_defaults(
+           self.builtins = rule_engine.builtins.Builtins.from_defaults(
                # expose the $version symbol
                {'version': rule_engine.__version__},
                # use the specified default timezone


### PR DESCRIPTION
The example for  subclassing the Context and setting from_defaults didn't work for me.  Assuming this is due to an api change I have edited the docs to reflect what seems to work.