### PR TITLE
Fix ends_with returning False for an empty suffix

### DIFF
--- a/lib/rule_engine/engine/_attribute_resolver.py
+++ b/lib/rule_engine/engine/_attribute_resolver.py
@@ -313,7 +313,10 @@ class _AttributeResolver(object):
         return functools.partial(self._value_ends_with, value)
 
     def _value_ends_with(self, value: Sequence[Any], suffix: Sequence[Any]) -> bool:
-        return value[-len(suffix):] == suffix
+        # index from the front (len(value) - len(suffix)) rather than the back
+        # (-len(suffix)) so an empty suffix yields an empty slice instead of the
+        # whole value; value[-0:] is value[0:], which made ends_with('') False
+        return value[len(value) - len(suffix):] == suffix
 
     @attribute('is_empty', types.DataType.ARRAY, types.DataType.BYTES, types.DataType.STRING, types.DataType.MAPPING, types.DataType.SET, result_type=types.DataType.BOOLEAN)
     def value_is_empty(self, value: Sized) -> bool:

--- a/tests/ast/expression/attribute.py
+++ b/tests/ast/expression/attribute.py
@@ -350,6 +350,38 @@ class GetAttributeExpressionTests(unittest.TestCase):
             self.assertTrue(callable(method), "attribute starts_with failed (method not callable)")
             self.assertEqual(method(prefix), result)
 
+    def test_ast_expression_value_methods_empty_affix(self):
+        # regression: an empty prefix/suffix must match any sequence, mirroring
+        # Python's str.startswith('') / str.endswith('') semantics. ends_with
+        # previously returned False for an empty suffix because
+        # value[-len(suffix):] is value[-0:] == value[0:] (the whole value)
+        # rather than an empty slice, diverging from its starts_with sibling.
+        cases = [
+                (ast.StringExpression, 'Rule Engine', '', 'Rule Engine'),
+                (ast.BytesExpression, b'Rule Engine', b'', b'Rule Engine'),
+        ]
+        for expression_class, value, empty, whole in cases:
+            for method_name in ('ends_with', 'starts_with'):
+                symbol = expression_class(context, value)
+                expression = ast.GetAttributeExpression(context, symbol, method_name)
+                method = expression.evaluate(None)
+                self.assertTrue(callable(method), "attribute {} failed (method not callable)".format(method_name))
+                # an empty affix always matches
+                self.assertTrue(method(empty), "{}({!r}) should be True".format(method_name, empty))
+                # the whole value is both a prefix and a suffix of itself
+                self.assertTrue(method(whole), "{}({!r}) should be True".format(method_name, whole))
+
+        # arrays behave the same as strings and bytes
+        array_expression = ast.ArrayExpression(context, [
+                ast.StringExpression(context, 'Rule'),
+                ast.StringExpression(context, 'Engine')
+        ])
+        for method_name in ('ends_with', 'starts_with'):
+            expression = ast.GetAttributeExpression(context, array_expression, method_name)
+            method = expression.evaluate(None)
+            self.assertTrue(method(()), "{}(()) should be True".format(method_name))
+            self.assertTrue(method(('Rule', 'Engine')), "{}(whole) should be True".format(method_name))
+
     def test_ast_expression_string_attributes_flt(self):
         combos = (
                 ('3.14159', decimal.Decimal('3.14159')),


### PR DESCRIPTION
## What

`ends_with` returns `False` for an empty suffix, contradicting Python's
`str.endswith('')` / `bytes.endswith(b'')` and its own `starts_with` sibling.

```python
'Rule Engine'.ends_with('')     # False — should be True
'Rule Engine'.starts_with('')   # True  (sibling is correct)
[1, 2].ends_with([])            # False — should be True
```

## Why

`_value_ends_with` slices from the back:

```python
return value[-len(suffix):] == suffix
```

For an empty suffix, `-len(suffix)` is `-0 == 0`, so the slice is `value[0:]`
— the **whole value** — and `whole == empty` is `False`. The sibling
`_value_starts_with` slices from the front (`value[:len(prefix)]`), which for
an empty prefix is `value[:0]` = an empty slice, correctly yielding `True`.
The two handlers disagree on the empty case even though every non-empty case
matches.

## Fix

Index from the front so an empty suffix yields an empty slice:

```python
return value[len(value) - len(suffix):] == suffix
```

Equivalent to the old expression for every non-empty suffix; correct for the
empty one.

## Tests

Added `test_ast_expression_value_methods_empty_affix`, exercising STRING,
BYTES and ARRAY through both `ends_with` and `starts_with`, asserting that an
empty affix and the whole value both match. It fails before the change
(`ends_with('') should be True`) and passes after. Full suite: `Ran 455 tests
... OK (skipped=31)`; `mypy` clean on the changed file.

---

This pull request was prepared with the assistance of AI, under my direction and review.
